### PR TITLE
Fix sidebar links by using ActiveModel route_key

### DIFF
--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -5,16 +5,24 @@ module Administrate
       render locals: locals, partial: field.to_partial_path
     end
 
-    def display_resource_name(resource_name)
+    def class_from_resource(resource_name)
       resource_name.
         to_s.
         classify.
-        constantize.
+        constantize
+    end
+
+    def display_resource_name(resource_name)
+      class_from_resource(resource_name).
         model_name.
         human(
           count: 0,
           default: resource_name.to_s.pluralize.titleize,
         )
+    end
+
+    def resource_index_route_key(resource_name)
+      ActiveModel::Naming.route_key(class_from_resource(resource_name))
     end
 
     def svg_tag(asset, svg_id, options = {})

--- a/app/views/administrate/application/_sidebar.html.erb
+++ b/app/views/administrate/application/_sidebar.html.erb
@@ -12,7 +12,7 @@ as defined by the routes in the `admin/` namespace
     <li>
       <%= link_to(
         display_resource_name(resource),
-        [namespace, resource],
+        [namespace, resource_index_route_key(resource)],
         class: "sidebar__link sidebar__link--#{nav_link_state(resource)}"
       ) %>
     </li>

--- a/spec/example_app/app/models/series.rb
+++ b/spec/example_app/app/models/series.rb
@@ -1,0 +1,3 @@
+class Series < ActiveRecord::Base
+  validates :name, presence: true
+end

--- a/spec/example_app/config/initializers/inflections.rb
+++ b/spec/example_app/config/initializers/inflections.rb
@@ -3,12 +3,12 @@
 # Add new inflection rules using the following format. Inflections
 # are locale specific, and you may define rules for as many different
 # locales as you wish. All of these examples are active by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
+ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.plural /^(ox)$/i, '\1en'
 #   inflect.singular /^(ox)en/i, '\1'
 #   inflect.irregular 'person', 'people'
-#   inflect.uncountable %w( fish sheep )
-# end
+  inflect.uncountable %w( series )
+end
 
 # These inflection rules are supported but not enabled by default:
 # ActiveSupport::Inflector.inflections(:en) do |inflect|

--- a/spec/example_app/db/migrate/20160117011028_create_series.rb
+++ b/spec/example_app/db/migrate/20160117011028_create_series.rb
@@ -1,0 +1,7 @@
+class CreateSeries < ActiveRecord::Migration
+  def change
+    create_table :series do |t|
+      t.string :name, null: false
+    end
+  end
+end

--- a/spec/example_app/db/schema.rb
+++ b/spec/example_app/db/schema.rb
@@ -17,10 +17,10 @@ ActiveRecord::Schema.define(version: 20160119024340) do
   enable_extension "plpgsql"
 
   create_table "customers", force: :cascade do |t|
-    t.string   "name",                                  null: false
-    t.string   "email",                                 null: false
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
+    t.string   "name",             null: false
+    t.string   "email",            null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
     t.boolean  "email_subscriber"
     t.string   "kind",             default: "standard", null: false
   end
@@ -78,6 +78,10 @@ ActiveRecord::Schema.define(version: 20160119024340) do
   end
 
   add_index "products", ["slug"], name: "index_products_on_slug", unique: true, using: :btree
+
+  create_table "series", force: :cascade do |t|
+    t.string "name", null: false
+  end
 
   add_foreign_key "line_items", "orders"
   add_foreign_key "line_items", "products"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -27,4 +27,8 @@ FactoryGirl.define do
     image_url \
       "https://cdn.recombu.com/mobile/images/news/M11370/1264769196_w670.jpg"
   end
+
+  factory :series do
+    sequence(:name) { |n| "Series #{n}" }
+  end
 end

--- a/spec/helpers/administrate/application_helper_spec.rb
+++ b/spec/helpers/administrate/application_helper_spec.rb
@@ -42,6 +42,18 @@ RSpec.describe Administrate::ApplicationHelper do
     end
   end
 
+  describe "#resource_index_route_key" do
+    it "handles index routes when resource is uncountable" do
+      route_key = resource_index_route_key(:series)
+      expect(route_key).to eq("series_index")
+    end
+
+    it "handles normal inflection" do
+      route_key = resource_index_route_key(:customer)
+      expect(route_key).to eq("customers")
+    end
+  end
+
   describe "#svg_tag" do
     it "returns use tag with svg file path in xlink:href attribute" do
       use_tag = build_svg_tag.xpath("//svg//use['xlink:href']")


### PR DESCRIPTION
This fixes the ActionController::UrlGenerationError thrown when the
sidebar partial tries to render index links on models which have an
uncountable inflection.